### PR TITLE
添加上传到相册功能

### DIFF
--- a/application/index/controller/Upload.php
+++ b/application/index/controller/Upload.php
@@ -210,11 +210,17 @@ class Upload extends Base
         $pathRule = $this->config['path_naming_rule'];
         $fileRule = $this->config['file_naming_rule'];
 
-        $path = trim(str_replace(
-            array_column($naming['path'], 'name'),
-            array_column($naming['path'], 'value'),
-            $pathRule
-        ), '/');
+        if ($pathRule === '{input}') {
+            $path = trim($_POST['album'], '/');
+        } elseif ($pathRule === '{input_with_user}') {
+            $path = trim($this->user->username . '/' . $_POST['album'], '/');
+        } else {
+            $path = trim(str_replace(
+                array_column($naming['path'], 'name'),
+                array_column($naming['path'], 'value'),
+                $pathRule
+            ), '/');
+        }
 
         if ($fileRule === '{original}') {
             $file = $name;

--- a/application/index/controller/Upload.php
+++ b/application/index/controller/Upload.php
@@ -211,9 +211,9 @@ class Upload extends Base
         $fileRule = $this->config['file_naming_rule'];
 
         if ($pathRule === '{input}') {
-            $path = trim($_POST['album'], '/');
+            $path = trim(input('album'), '/');
         } elseif ($pathRule === '{input_with_user}') {
-            $path = trim($this->user->username . '/' . $_POST['album'], '/');
+            $path = trim($this->user->username . '/' . input('album'), '/');
         } else {
             $path = trim(str_replace(
                 array_column($naming['path'], 'name'),

--- a/application/index/view/index/index.html
+++ b/application/index/view/index/index.html
@@ -25,7 +25,7 @@
       <form action="" method="post" enctype="multipart/form-data">
         <input id="image" style="display: none;" type="file" multiple name="image" accept="image/*">
         <br>
-        <input id="album" class="input-group form-control" type="text" name="album" placeholder="上传到相册" tabindex="500">
+        <input id="album" class="input-group form-control" type="text" name="album" placeholder="上传到相册，{input} 模式不可留空，{input_with_user} 模式可留空" tabindex="500">
       </form>
       <div class="success-info">
         <div class="mdui-tab mdui-tab-scrollable" mdui-tab>

--- a/application/index/view/index/index.html
+++ b/application/index/view/index/index.html
@@ -24,6 +24,8 @@
       </div>
       <form action="" method="post" enctype="multipart/form-data">
         <input id="image" style="display: none;" type="file" multiple name="image" accept="image/*">
+        <br>
+        <input id="album" class="input-group form-control" type="text" name="album" placeholder="上传到相册" tabindex="500">
       </form>
       <div class="success-info">
         <div class="mdui-tab mdui-tab-scrollable" mdui-tab>
@@ -100,6 +102,12 @@
     //browseClass: "btn btn-file",
     maxFileSize: "{$config.upload_max_size / 1024}",// kb
     maxFileCount: "{$config.upload_single_num}",
+    uploadExtraData: function(previewId, index) {
+                    var data = {
+                        album : $('#album').val(),
+                    };
+                    return data;
+                },
     showCaption: true,
     dropZoneEnabled: true,
     browseIcon: "<i class=\"glyphicon glyphicon-picture\"></i> ",

--- a/config/naming.php
+++ b/config/naming.php
@@ -87,6 +87,18 @@ return [
             'explain' => '16位随机字符串',
             'value' => str_rand(),
         ],
+        [
+            'name' => '{input}',
+            'example' => 'life、宠物',
+            'explain' => '上传到相册名字，上传时由用户输入指定，比如上传时输入 life，则会上传到 path-store/life/文件夹下',
+            'value' => $md5,
+        ],
+        [
+            'name' => '{input_with_user}',
+            'example' => 'life、宠物',
+            'explain' => '上传到相册名字，上传时由用户输入指定，路径带有当前用户名前缀，比如上传时输入 life，则会上传到: path-store/username/life/文件夹下',
+            'value' => $md5,
+        ],
     ],
     'file' => [
         [


### PR DESCRIPTION
在上传页面增加一个输入框，可以输入本次上传到某个相册（文件夹），可留空
增加了两种上传文件路径命名规则：
1. input: 上传时由用户输入指定上传到某个相册，如上传时输入 `life`，则会上传到 `life` 文件夹下
2. input_with_user: 上传时由用户输入指定上传到某个相册，按用户区分，比如上传时输入 `life`，则会上传到 `username/life` 文件夹下
本地存储与七牛云均可以，别的第三方存储应该也可以

相关 issues：
#2 
#43 
#56 