### PR TITLE
Update ApiAuthenticate.php

### DIFF
--- a/application/http/middleware/ApiAuthenticate.php
+++ b/application/http/middleware/ApiAuthenticate.php
@@ -28,6 +28,10 @@ class ApiAuthenticate
 
         $user = null;
         $token = $request->header('token', $request->request('token'));
+        if (!$token) {
+            $token = = $request->header('authorization', '');
+        }
+        
         if ($token) {
             if (!$user = Users::get(['token' => $token])) {
                 $this->response('认证失败', [], 401);


### PR DESCRIPTION
HTTP 标准要求用 Authorization 头部进行认证。增加兼容。